### PR TITLE
feat(button): icon type

### DIFF
--- a/src/button/ux-button-theme.css
+++ b/src/button/ux-button-theme.css
@@ -76,6 +76,18 @@ styles.button.flat:active {
   background-color: ${background || $swatches.grey.p300};
 }
 
+styles.button.icon {
+  display: inline-flex;
+  align-content: center;
+  justify-content: center;
+
+  width: 40px;
+  height: 40px;
+
+  background-color: transparent;
+  color: ${foreground || $design.accent};
+}
+
 styles.button.fab {
   border-radius: 50%;
   overflow: hidden;

--- a/src/button/ux-button-theme.ts
+++ b/src/button/ux-button-theme.ts
@@ -2,7 +2,7 @@ import {styles} from '../styles/decorators';
 
 @styles()
 export class UxButtonTheme {
-  public type = 'raised'; // flat, raised or fab
+  public type = 'raised'; // flat, raised, icon or fab
   public size = 'medium'; // small, medium or large
   public effect = 'ripple'; // ripple or none
 

--- a/src/button/ux-button.ts
+++ b/src/button/ux-button.ts
@@ -42,6 +42,11 @@ export class UxButton implements Themable {
         this.button.appendChild(this.ripple.$);
       }
 
+      if (this.button.classList.contains('icon')) {
+        this.ripple.center = true;
+        this.ripple.round = true;
+      }
+
       if (this.button.classList.contains('fab')) {
         this.ripple.center = true;
         this.ripple.round = true;


### PR DESCRIPTION
addition to the button class enabling icon buttons to be made that are good for displaying in a list as a secondary action or in toolbars where buttons do not have backgrounds and need to be square

Usage:
``` html
<ux-button type="icon">
  <i class="material-icons more_vert"></i>
</ux-button>
```